### PR TITLE
chore: Add unit and integration tests, group Dockerfile and go.mod renovate PRs

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -44,4 +44,14 @@ jobs:
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         push: false
+        load: true
         tags: ${{ github.repository }}:test
+
+    - name: Run Docker integration test
+      run: |
+        docker run -d --name hello-test -p 8080:8080 ${{ github.repository }}:test
+        timeout 15 sh -c 'until curl -sf http://localhost:8080/hello | grep -q "response"; do sleep 1; done'
+
+    - name: Remove test container
+      if: always()
+      run: docker rm -f hello-test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,6 +49,16 @@ jobs:
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         push: true
+        load: true
         tags: ghcr.io/${{ github.repository }}:latest
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}
+
+    - name: Run Docker integration test
+      run: |
+        docker run -d --name hello-test -p 8080:8080 ghcr.io/${{ github.repository }}:latest
+        timeout 15 sh -c 'until curl -sf http://localhost:8080/hello | grep -q "response"; do sleep 1; done'
+
+    - name: Remove test container
+      if: always()
+      run: docker rm -f hello-test

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestHelloHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseString string
+		appInfo        string
+		wantStatus     int
+		wantResponse   string
+		wantInfo       string
+	}{
+		{
+			name:           "default response",
+			responseString: "Hello from go code",
+			appInfo:        "",
+			wantStatus:     http.StatusOK,
+			wantResponse:   "Hello from go code",
+			wantInfo:       "Application info; ",
+		},
+		{
+			name:           "custom response with app info",
+			responseString: "custom response",
+			appInfo:        "v1.0.0",
+			wantStatus:     http.StatusOK,
+			wantResponse:   "custom response",
+			wantInfo:       "Application info; v1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responseString = tt.responseString
+			os.Setenv("APP_INFO", tt.appInfo)
+			defer os.Unsetenv("APP_INFO")
+
+			req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+			w := httptest.NewRecorder()
+
+			helloHandler(w, req)
+
+			res := w.Result()
+			if res.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", res.StatusCode, tt.wantStatus)
+			}
+			if ct := res.Header.Get("Content-Type"); ct != "application/json; charset=utf-8" {
+				t.Errorf("Content-Type = %q, want %q", ct, "application/json; charset=utf-8")
+			}
+			var body WebResponse
+			if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body.Response != tt.wantResponse {
+				t.Errorf("Response = %q, want %q", body.Response, tt.wantResponse)
+			}
+			if body.Info != tt.wantInfo {
+				t.Errorf("Info = %q, want %q", body.Info, tt.wantInfo)
+			}
+		})
+	}
+}
+
+func TestErrorHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+	}{
+		{
+			name:       "zero error rate always returns OK",
+			query:      "/errors?500=0",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "101 error rate always returns internal server error",
+			query:      "/errors?500=101",
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "no param defaults to zero error rate",
+			query:      "/errors",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.query, nil)
+			w := httptest.NewRecorder()
+
+			errorHandler(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 )
 
@@ -38,8 +37,7 @@ func TestHelloHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			responseString = tt.responseString
-			os.Setenv("APP_INFO", tt.appInfo)
-			defer os.Unsetenv("APP_INFO")
+			t.Setenv("APP_INFO", tt.appInfo)
 
 			req := httptest.NewRequest(http.MethodGet, "/hello", nil)
 			w := httptest.NewRecorder()

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,12 @@
         "github-actions"
       ],
       "pinDigests": true
+    },
+    {
+      "matchManagers": ["dockerfile", "gomod"],
+      "matchPackageNames": ["golang", "go"],
+      "groupName": "go version",
+      "groupSlug": "go-version"
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces automated integration testing for the Docker image in the CI workflows, adds comprehensive unit tests for the main HTTP handlers, and improves dependency management for Go version updates. The changes enhance the reliability of the build process and codebase, ensuring both the application and its Dockerized version are tested and maintained more effectively.

**CI/CD Enhancements:**

* Added Docker integration tests to both `branches.yaml` and `master.yml` GitHub Actions workflows, ensuring that the built Docker image is started and its `/hello` endpoint is verified before proceeding. Also included cleanup steps to remove the test container after the test run. (`.github/workflows/branches.yaml`, `.github/workflows/master.yml`) [[1]](diffhunk://#diff-5257bd15fb502a582870020b9e08c84ca0739ac7ba40390cb31e5404405e56d5R47-R57) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842R52-R64)

**Testing Improvements:**

* Added `main_test.go` with unit tests for `helloHandler` and `errorHandler`, covering different response scenarios and error rates to ensure correct HTTP status codes and response bodies. (`main_test.go`)

**Dependency Management:**

* Updated `renovate.json` to group Go version updates (for both Dockerfile and Go modules) into a single PR, simplifying dependency update management. (`renovate.json`)