### PR TITLE
chore: make renovate not try to pin version of golangxi/golangci-lint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,10 @@
     {
       "matchManagers": ["github-actions", "dockerfile"],
       "semanticCommitType": "chore"
+    },
+    {
+      "matchPackageNames": ["golangci/golangci-lint"],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
suspecting this to be the source of renovate sync issues